### PR TITLE
Make list of posts use css grid

### DIFF
--- a/src/components/shared/Posts/Post.styles.ts
+++ b/src/components/shared/Posts/Post.styles.ts
@@ -6,21 +6,7 @@ export default ({
   },
 }: IProps): IStyles => ({
   container: {
-    display: 'inline-block',
-    height: '300px',
-    maxHeight: '300px',
-    maxWidth: '390px',
-    padding: '40px 12px',
     position: 'relative',
-    width: '390px',
-  },
-
-  image: {
-    height: '100%',
-    left: '0',
-    position: 'absolute',
-    top: '0',
-    width: '100%',
   },
 
   sectionWrapper: {

--- a/src/components/shared/Posts/Post.tsx
+++ b/src/components/shared/Posts/Post.tsx
@@ -18,9 +18,7 @@ export const Post: React.FunctionComponent<IProps> = ({
   return (
     <article className={styles.container}>
       {post.node.cover && (
-        <div className={styles.image}>
-          <Img fluid={post.node.cover.fluid} title={post.node.cover.title} />
-        </div>
+        <Img fluid={post.node.cover.fluid} title={post.node.cover.title} />
       )}
 
       <div className={styles.sectionWrapper}>

--- a/src/components/shared/Posts/Post.types.ts
+++ b/src/components/shared/Posts/Post.types.ts
@@ -11,8 +11,6 @@ export interface IOwnProps {
 export interface IStyles {
   container: IStyle;
 
-  image: IStyle;
-
   sectionWrapper: IStyle & {
     ':hover': IStyle;
   };

--- a/src/components/shared/Posts/Posts.styles.ts
+++ b/src/components/shared/Posts/Posts.styles.ts
@@ -2,12 +2,11 @@ import { IStyles } from './Posts.types';
 
 export default (): IStyles => ({
   container: {
-    display: 'flex',
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    margin: '60px auto 0 auto',
+    display: 'grid',
+    gridGap: '5px',
+    gridTemplateColumns: 'repeat(auto-fit, minmax(320px, 1fr))',
+    margin: '0 auto',
     maxWidth: '1170px',
-    minHeight: '100%',
-    textAlign: 'center',
+    padding: '60px 17px 0 17px',
   },
 });


### PR DESCRIPTION
Resolves issues observed in non-chrome browsers where grid sticks to left side.